### PR TITLE
Add dry run mode and wait for job completion before sacct collection

### DIFF
--- a/slurm_benchmark/runner.py
+++ b/slurm_benchmark/runner.py
@@ -56,6 +56,14 @@ class SlurmBenchmark:
     sbatch_path:
         Override the executable used for sbatch. Defaults to ``sbatch`` which must be
         available in ``PATH`` when the library is used.
+    dryrun:
+        When ``True``, commands are only printed instead of submitted to Slurm and no
+        statistics are collected.
+    squeue_path:
+        Override the executable used for squeue when waiting for jobs to finish.
+    squeue_poll_interval:
+        Delay (in seconds) between squeue polling attempts while waiting for jobs to
+        complete.
     """
 
     command_template: Sequence[str]
@@ -68,6 +76,9 @@ class SlurmBenchmark:
     sbatch_path: str = "sbatch"
     extra_sacct_args: Sequence[str] = field(default_factory=list)
     extra_sbatch_args: Sequence[str] = field(default_factory=list)
+    dryrun: bool = False
+    squeue_path: str = "squeue"
+    squeue_poll_interval: float = 5.0
 
     def run(self) -> pd.DataFrame:
         """Submit the benchmarking jobs and collect the sacct output."""
@@ -94,10 +105,13 @@ class SlurmBenchmark:
             if self.delay:
                 time.sleep(self.delay)
 
-        sacct_records = self._collect_sacct(job_records)
+        if not self.dryrun:
+            sacct_records = self._collect_sacct(job_records)
 
-        for record, sacct_record in zip(job_records, sacct_records):
-            record.update({f"sacct_{key}": value for key, value in sacct_record.items()})
+            for record, sacct_record in zip(job_records, sacct_records):
+                record.update(
+                    {f"sacct_{key}": value for key, value in sacct_record.items()}
+                )
 
         return pd.DataFrame(job_records)
 
@@ -120,6 +134,19 @@ class SlurmBenchmark:
             sbatch_cmd.extend([normalized_option, str(value)])
         sbatch_cmd.extend(["--wrap", wrapped_command])
 
+        record: MutableMapping[str, object] = {
+            "job_id": None,
+            "job_name": job_name,
+            "params": params,
+            "resources": resources,
+            "sbatch_command": sbatch_cmd,
+            "wrapped_command": wrapped_command,
+        }
+
+        if self.dryrun:
+            print(" ".join(shlex.quote(part) for part in sbatch_cmd))
+            return record
+
         result = subprocess.run(
             sbatch_cmd,
             check=True,
@@ -135,14 +162,7 @@ class SlurmBenchmark:
 
         job_id = job_id_match.group(1)
 
-        record: MutableMapping[str, object] = {
-            "job_id": job_id,
-            "job_name": job_name,
-            "params": params,
-            "resources": resources,
-            "sbatch_command": sbatch_cmd,
-            "wrapped_command": wrapped_command,
-        }
+        record["job_id"] = job_id
         return record
 
     # ------------------------------------------------------------------
@@ -150,6 +170,7 @@ class SlurmBenchmark:
         sacct_records: List[Dict[str, str]] = []
         for record in job_records:
             job_id = str(record["job_id"])
+            self._wait_for_job_completion(job_id)
             sacct_cmd = [
                 self.sacct_path,
                 "-j",
@@ -168,6 +189,23 @@ class SlurmBenchmark:
             )
             sacct_records.append(self._parse_sacct_output(result.stdout))
         return sacct_records
+
+    # ------------------------------------------------------------------
+    def _wait_for_job_completion(self, job_id: str) -> None:
+        while True:
+            result = subprocess.run(
+                [self.squeue_path, "-j", job_id, "-h"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    "Failed to query job status via squeue: " f"{result.stderr!r}"
+                )
+            if not result.stdout.strip():
+                break
+            time.sleep(self.squeue_poll_interval)
 
     # ------------------------------------------------------------------
     def _parse_sacct_output(self, output: str) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- add a dry-run mode that prints the constructed sbatch commands without submitting jobs
- record submission metadata without job IDs when dry-running so results can still be inspected
- wait for each job to disappear from squeue before gathering sacct statistics

## Testing
- python -m compileall slurm_benchmark

------
https://chatgpt.com/codex/tasks/task_e_68f9636ec31483239954a47b503398a1